### PR TITLE
Dynamically Create Zone Sensors After Initial Connection to Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,21 @@ Go to the integrations page in your configuration and click on new **Integration
 
 ### Sensor
 
-This component will create these sensors in the format of `{ultrasync_hubname}_{sensor}`;  The below example assumes you accept the default name of `UltraSync` (which is still represented in lowercase):
+Sensors are dynamically generated on the fly.
+
+Sensors follow the following naming convention: `{ultrasync_integration}_{sensor}`.  The `{ultrasync_integration}` refers to the name you called your integration when you set it up (the default is `Ultrasync` so it is referenced in it's slug form `ultrasync`):
 
 - `ultrasync_area1state`: The Area 1 State
 - `ultrasync_area2state`: The Area 2 State
-- `ultrasync_area3state`: The Area 3 State
-- `ultrasync_area4state`: The Area 4 State
+- `ultrasync_areaXstate`: The Area X State
+
+Zone sensors work the same way and only load what is detected:
+
+- `ultrasync_zone1state`: The Zone 1 State
+- `ultrasync_zone2state`: The Zone 2 State
+- `ultrasync_zoneXstate`: The Zone X State
+
+The attributes read from the hub are associated with each Detected Zone and Area; so you can rename them to something more appropriate if you feel the need.
 
 There are several states each sensor can be at, but usually they will be one of the following: `Unknown`, `Ready`, `Not Ready`, `Armed Stay`, and `Armed Away`.  The `Unknown` state is assigned to sensors that are not reporting; they usually sit in the spots of the Area's you're not monitoring.
 
@@ -59,7 +68,9 @@ When an Zone or Sensor changes it's state an event usable for automation is trig
 Possible events are:
 
 - `ultrasync_sensor_update`: The event includes the sensor no, name, and new status it changed to.
-- `ultrasync_area_update`: The event includes the area no, name, and new status it changed to (if it did). **Note**: Area's are sent periodic heartbeats in which case the state will not change at all.
+- `ultrasync_area_update`: The event includes the area no, name, and new status it changed to (if it did).
+
+**Note**: Area's are sent periodic heartbeats with Interlogix devices in which case the state will not change at all.
 
 Example automation to send a message via [Apprise](https://www.home-assistant.io/integrations/apprise/) on a sensor change in your home:
 
@@ -107,8 +118,8 @@ As an example you may want to `arm` your alarm in `stay` mode each night and dis
 
 A card I use that created and works quite well can be found in this repository as well called [`ultrasync_alarm.yaml`](https://raw.githubusercontent.com/caronc/ha-ultrasync/main/ultrasync_alarm.yaml) found at the root of this GitHub repository.  It requires that you additionally have the following resources already pre-added:
 
- - **layout-card**: [Source](https://github.com/thomasloven/lovelace-layout-card)
- - **button-card**: [Source](https://github.com/custom-cards/button-card)
+- **layout-card**: [Source](https://github.com/thomasloven/lovelace-layout-card)
+- **button-card**: [Source](https://github.com/custom-cards/button-card)
 
 The `ultrasync_alarm.yaml` looks like this:
 ![Lovelace UltraSync Card](https://raw.githubusercontent.com/caronc/ha-ultrasync/main/ultrasync_alarm-card-preview.gif)

--- a/custom_components/ultrasync/__init__.py
+++ b/custom_components/ultrasync/__init__.py
@@ -15,6 +15,7 @@ from .const import (
     DATA_COORDINATOR,
     DATA_UNDO_UPDATE_LISTENER,
     DEFAULT_SCAN_INTERVAL,
+    SENSORS,
     DOMAIN,
     SERVICE_AWAY,
     SERVICE_DISARM,
@@ -57,7 +58,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_COORDINATOR: coordinator,
-        DATA_UNDO_UPDATE_LISTENER: undo_listener,
+        DATA_UNDO_UPDATE_LISTENER: [undo_listener],
+        SENSORS: {},
     }
 
     for component in PLATFORMS:
@@ -82,7 +84,8 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> boo
     )
 
     if unload_ok:
-        hass.data[DOMAIN][entry.entry_id][DATA_UNDO_UPDATE_LISTENER]()
+        for unsub in hass.data[DOMAIN][entry.entry_id][DATA_UNDO_UPDATE_LISTENER]:
+            unsub()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/ultrasync/const.py
+++ b/custom_components/ultrasync/const.py
@@ -14,3 +14,4 @@ SERVICE_DISARM = "disarm"
 
 DATA_COORDINATOR = "coordinator"
 DATA_UNDO_UPDATE_LISTENER = "undo_update_listener"
+ZONE_LISTENER = "ultrasync_create_zone"

--- a/custom_components/ultrasync/const.py
+++ b/custom_components/ultrasync/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "ultrasync"
 
 # Scan Time (in seconds)
-DEFAULT_SCAN_INTERVAL = 5
+DEFAULT_SCAN_INTERVAL = 1
 
 DEFAULT_NAME = "UltraSync"
 
@@ -12,6 +12,9 @@ SERVICE_AWAY = "away"
 SERVICE_STAY = "stay"
 SERVICE_DISARM = "disarm"
 
+# Index used for managing loaded sensors
+SENSORS = "sensors"
+
 DATA_COORDINATOR = "coordinator"
 DATA_UNDO_UPDATE_LISTENER = "undo_update_listener"
-ZONE_LISTENER = "ultrasync_create_zone"
+SENSOR_UPDATE_LISTENER = "ultrasync_update_sensors"

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import ZONE_LISTENER, DOMAIN
+from .const import SENSOR_UPDATE_LISTENER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,17 +48,13 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
             """Fetch data from UltraSync via sync functions."""
 
             # initialize our response
-            response = {
-                "area01_state": "unknown",
-                "area02_state": "unknown",
-                "area03_state": "unknown",
-                "area04_state": "unknown",
-            }
+            response = {}
 
             # Update our details
             details = self.hub.details(max_age_sec=0)
             if details:
-                async_dispatcher_send(self.hass, ZONE_LISTENER, details['zones'])
+                async_dispatcher_send(
+                    self.hass, SENSOR_UPDATE_LISTENER, details['areas'], details['zones'])
 
                 for zone in details["zones"]:
                     if self._zone_delta.get(zone["bank"]) != zone["sequence"]:
@@ -97,6 +93,7 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                     response["area{:0>2}_state".format(area["bank"] + 1)] = area[
                         "status"
                     ]
+
             self._init = True
 
             # Return our response

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -10,18 +10,17 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import HomeAssistantType
 
-from . import UltraSyncEntity
-from .const import ZONE_LISTENER, DATA_COORDINATOR, DOMAIN
 from .coordinator import UltraSyncDataUpdateCoordinator
+from . import UltraSyncEntity
+from .const import (
+    DATA_COORDINATOR,
+    DATA_UNDO_UPDATE_LISTENER,
+    DOMAIN,
+    SENSORS,
+    SENSOR_UPDATE_LISTENER,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-SENSORS = {
-    "area01_state": "Area1State",
-    "area02_state": "Area2State",
-    "area03_state": "Area3State",
-    "area04_state": "Area4State",
-}
 
 
 async def async_setup_entry(
@@ -33,50 +32,87 @@ async def async_setup_entry(
     coordinator: UltraSyncDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]
-    sensors = []
 
-    for sensor_type, sensor_name in SENSORS.items():
-        sensors.append(
-            UltraSyncSensor(
-                coordinator,
-                entry.entry_id,
-                entry.data[CONF_NAME],
-                sensor_type,
-                sensor_name,
-            )
-        )
+    # At least one sensor must be pre-created or Home Assistant will not
+    # call any updates
+    hass.data[DOMAIN][entry.entry_id][SENSORS]['area01_state'] = \
+        UltraSyncSensor(
+            coordinator,
+            entry.entry_id,
+            entry.data[CONF_NAME],
+            'area01_state',
+            'Area1State')
 
-    async_add_entities(sensors)
-
-    _zones = {}
+    async_add_entities([
+        hass.data[DOMAIN][entry.entry_id][SENSORS]['area01_state']])
 
     @callback
-    def _prepare_zone_sensors(zones: dict) -> None:
-        """Dynamically create sensors based on detected zones."""
+    def _auto_manage_sensors(areas: dict, zones: dict) -> None:
+        """Dynamically create/delete sensors based on what was detected by the hub."""
 
-        # our list of zones to add
-        sensors = []
+        _LOGGER.debug(
+            "Entering _auto_manage_sensors with {} area(s), and {} zone(s)".format(
+                len(areas), len(zones)))
 
-        for meta in zones:
+        # our list of sensors to add
+        new_sensors = []
+
+        # A pointer to our sensors
+        sensors = hass.data[DOMAIN][entry.entry_id][SENSORS]
+
+        for meta in areas:
             bank_no = meta['bank']
-            if bank_no not in _zones:
+            sensor_id = "area{:0>2}_state".format(bank_no + 1)
+            if sensor_id not in sensors:
                 # hash our entry
-                _zones[bank_no] = UltraSyncSensor(
+                sensors[sensor_id] = UltraSyncSensor(
                     coordinator,
                     entry.entry_id,
                     entry.data[CONF_NAME],
-                    "zone{:0>2}_state".format(bank_no + 1),
+                    sensor_id,
+                    # Friendly Name
+                    "Area{}State".format(bank_no + 1),
+                )
+
+                # Add our new area sensor
+                new_sensors.append(sensors[sensor_id])
+                _LOGGER.debug("Detected {}.Area{}State".format(entry.data[CONF_NAME], bank_no + 1))
+
+            # Update our meta information
+            for key, value in meta.items():
+                sensors[sensor_id][key] = value
+
+        for meta in zones:
+            bank_no = meta['bank']
+            sensor_id = "zone{:0>2}_state".format(bank_no + 1)
+            if sensor_id not in sensors:
+                # hash our entry
+                sensors[sensor_id] = UltraSyncSensor(
+                    coordinator,
+                    entry.entry_id,
+                    entry.data[CONF_NAME],
+                    sensor_id,
+                    # Friendly Name
                     "Zone{}State".format(bank_no + 1),
                 )
-                # Add our bank
-                sensors.append(_zones[bank_no])
 
-        if sensors:
-            async_add_entities(sensors)
+                # Add our new zone sensor
+                new_sensors.append(sensors[sensor_id])
+                _LOGGER.debug("Detected {}.Zone{}State".format(entry.data[CONF_NAME], bank_no + 1))
+
+            # Update our meta information
+            for key, value in meta.items():
+                sensors[sensor_id][key] = value
+
+        if new_sensors:
+            # Add our newly detected sensors
+            async_add_entities(new_sensors)
 
     # register our callback which will be called the second we make a
     # connection to our panel
-    async_dispatcher_connect(hass, ZONE_LISTENER, _prepare_zone_sensors)
+    hass.data[DOMAIN][entry.entry_id][DATA_UNDO_UPDATE_LISTENER].append(
+        async_dispatcher_connect(hass, SENSOR_UPDATE_LISTENER, _auto_manage_sensors)
+    )
 
 
 class UltraSyncSensor(UltraSyncEntity):
@@ -95,16 +131,28 @@ class UltraSyncSensor(UltraSyncEntity):
         self._sensor_type = sensor_type
         self._unique_id = f"{entry_id}_{sensor_type}"
 
+        # Initialize our Attributes
+        self.__attributes = {}
+
         super().__init__(
             coordinator=coordinator,
             entry_id=entry_id,
             name=f"{entry_name} {sensor_name}",
         )
 
+    def __setitem__(self, key, value):
+        """Sets our attributes."""
+        self.__attributes[key] = value
+
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
         return self._unique_id
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self.__attributes
 
     @property
     def state(self):

--- a/ultrasync_alarm.yaml
+++ b/ultrasync_alarm.yaml
@@ -32,7 +32,7 @@ cards:
     tap_action:
       action: >
         [[[
-          if (entity.state.startsWith("Armed") || entity.state.includes("Delay"))
+          if (entity.state.startsWith("Armed") || entity.state.includes("Delay") || entity.state.includes("Alarm"))
               return "call-service";
           else
               return "none";


### PR DESCRIPTION
Initialize the zones/sensors associated with the UltraSync hub such as `NAME_zoneNOstate` such as `ultrasync_zone13state`.  These will carry the sensor states associated with the hub such as `Ready`, `Not Ready`, etc