### PR TITLE
Output Control Support

### DIFF
--- a/custom_components/ultrasync/__init__.py
+++ b/custom_components/ultrasync/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     SERVICE_STAY,
     SERVICE_BYPASS,
     SERVICE_UNBYPASS,
+    SERVICE_SWITCH
 )
 from .coordinator import UltraSyncDataUpdateCoordinator
 
@@ -117,13 +118,20 @@ def _async_register_services(
     def unbypass(call) -> None:
         """Service call to unbypass a zone in UltraSync Hub."""
         coordinator.hub.set_zone_bypass(state=False, zone=call.data['zone'])
+    
+    def switch(call) -> None:
+        """Service call to switch on/off an output control in UltraSync Hub."""
+        coordinator.hub.set_output_control(output=call.data['output'], state=call.data['state'])
 
     hass.services.async_register(DOMAIN, SERVICE_AWAY, away, schema=vol.Schema({}))
     hass.services.async_register(DOMAIN, SERVICE_STAY, stay, schema=vol.Schema({}))
     hass.services.async_register(DOMAIN, SERVICE_DISARM, disarm, schema=vol.Schema({}))
     hass.services.async_register(DOMAIN, SERVICE_BYPASS, bypass)
     hass.services.async_register(DOMAIN, SERVICE_UNBYPASS, unbypass)
-
+    hass.services.async_register(DOMAIN, SERVICE_SWITCH, switch, schema=vol.Schema({
+        vol.Required('output'): vol.Coerce(int),
+        vol.Required('state'): vol.Coerce(int),
+    }))
 
 async def _async_update_listener(hass: HomeAssistantType, entry: ConfigEntry) -> None:
     """Handle options update."""

--- a/custom_components/ultrasync/const.py
+++ b/custom_components/ultrasync/const.py
@@ -13,6 +13,7 @@ SERVICE_STAY = "stay"
 SERVICE_DISARM = "disarm"
 SERVICE_BYPASS = "bypass"
 SERVICE_UNBYPASS = "unbypass"
+SERVICE_SWITCH = "switch"
 
 # Index used for managing loaded sensors
 SENSORS = "sensors"

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -102,7 +102,7 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                 output_index = 1
                 for output in details["outputs"]:
                     # Use the output name if it's not empty, otherwise use the index
-                    output_identifier = output["name"] if output["name"].strip() else f"output{output_index}"
+                    output_identifier = f"output{output_index}_state"
 
                     if self._output_delta.get(output_identifier) != output["state"]:
                         self.hass.bus.fire(
@@ -117,10 +117,10 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                         self._output_delta[output_identifier] = output["state"]
 
                     # Set our state:
-                    response[f"output_{output_identifier}"] = output["state"]
+                    response[output_identifier] = output["state"]
 
                     output_index += 1
-                    
+
             self._init = True
 
             # Return our response

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -98,7 +98,8 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                     response["area{:0>2}_state".format(area["bank"] + 1)] = area[
                         "status"
                     ]
-                
+
+                output_index = 1
                 for output in details["outputs"]:
                     if self._output_delta.get(output["name"]) != output["state"]:
                         self.hass.bus.fire(
@@ -113,9 +114,10 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                         self._output_delta[output["name"]] = output["state"]
 
                     # Set our state:
-                    response["output{}state".format(output["name"])] = output[
+                    response["output{}state".format(output_index)] = output[
                         "state"
                     ]
+                    output_index += 1
 
             self._init = True
 

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -100,22 +100,22 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                     ]
                 
                 for output in details["outputs"]:
-                    _LOGGER.info(output)
-                    if self._output_delta.get(output["name"]) != output["status"]:
+                    _LOGGER.debug(output)
+                    if self._output_delta.get(output["name"]) != output["state"]:
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {
                                 "name": output["name"] + 1,
-                                "status": output["status"],
+                                "status": output["state"],
                             },
                         )
 
                         # Update our sequence
-                        self._output_delta[output["name"]] = output["status"]
+                        self._output_delta[output["name"]] = output["state"]
 
                     # Set our state:
                     response["output{}state".format(output["name"] + 1)] = output[
-                        "status"
+                        "state"
                     ]
 
             self._init = True

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -100,12 +100,12 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                     ]
                 
                 for output in details["outputs"]:
-                    _LOGGER.debug(output)
                     if self._output_delta.get(output["name"]) != output["state"]:
+                        _LOGGER.debug(output)
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {
-                                "name": output["name"] + 1,
+                                "name": output["name"],
                                 "status": output["state"],
                             },
                         )
@@ -114,7 +114,7 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                         self._output_delta[output["name"]] = output["state"]
 
                     # Set our state:
-                    response["output{}state".format(output["name"] + 1)] = output[
+                    response["output{}state".format(output["name"])] = output[
                         "state"
                     ]
 

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -99,22 +99,28 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                         "status"
                     ]
                 
+                output_index = 1
                 for output in details["outputs"]:
-                    if self._output_delta.get(output["name"]) != output["state"]:
+                    # Use the output name if it's not empty, otherwise use the index
+                    output_identifier = output["name"] if output["name"].strip() else f"output{output_index}"
+
+                    if self._output_delta.get(output_identifier) != output["state"]:
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {
-                                "name": output["name"],
+                                "name": output_identifier,
                                 "status": output["state"],
                             },
                         )
 
                         # Update our sequence
-                        self._output_delta[output["name"]] = output["state"]
+                        self._output_delta[output_identifier] = output["state"]
 
                     # Set our state:
-                    response[f"output_{output['name']}"] = output["state"]
+                    response[f"output_{output_identifier}"] = output["state"]
 
+                    output_index += 1
+                    
             self._init = True
 
             # Return our response

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -100,20 +100,23 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                     ]
                 
                 for output in details["outputs"]:
-                    if self._output_delta.get(output["name"]) != output["state"]:
+                    _LOGGER.info(output)
+                    if self._output_delta.get(output["name"]) != output["status"]:
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {
-                                "name": output["name"],
-                                "status": output["state"],
+                                "name": output["name"] + 1,
+                                "status": output["status"],
                             },
                         )
 
                         # Update our sequence
-                        self._output_delta[output["name"]] = output["state"]
+                        self._output_delta[output["name"]] = output["status"]
 
                     # Set our state:
-                    response[f"output_{output['name']}"] = output["state"]
+                    response["output{}state".format(output["name"] + 1)] = output[
+                        "status"
+                    ]
 
             self._init = True
 

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -101,7 +101,6 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                 
                 for output in details["outputs"]:
                     if self._output_delta.get(output["name"]) != output["state"]:
-                        _LOGGER.debug(output)
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -121,6 +121,8 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
 
                     output_index += 1
 
+                    _LOGGER.debug("Updated response keys: %s", response.keys())
+
             self._init = True
 
             # Return our response

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -99,29 +99,21 @@ class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
                         "status"
                     ]
                 
-                output_index = 1
                 for output in details["outputs"]:
-                    # Use the output name if it's not empty, otherwise use the index
-                    output_identifier = f"output{output_index}_state"
-
-                    if self._output_delta.get(output_identifier) != output["state"]:
+                    if self._output_delta.get(output["name"]) != output["state"]:
                         self.hass.bus.fire(
                             "ultrasync_output_update",
                             {
-                                "name": output_identifier,
+                                "name": output["name"],
                                 "status": output["state"],
                             },
                         )
 
                         # Update our sequence
-                        self._output_delta[output_identifier] = output["state"]
+                        self._output_delta[output["name"]] = output["state"]
 
                     # Set our state:
-                    response[output_identifier] = output["state"]
-
-                    output_index += 1
-
-                    _LOGGER.debug("Updated response keys: %s", response.keys())
+                    response[f"output_{output['name']}"] = output["state"]
 
             self._init = True
 

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -114,7 +114,7 @@ async def async_setup_entry(
         output_index = 1
         for meta in outputs:
             output_name = meta["name"]
-            sensor_id = f"output_{output_index}state"
+            sensor_id = f"output_{output_name}"
             detected_sensors.add(sensor_id)
             if sensor_id not in sensors:
                 # hash our entry

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -124,7 +124,7 @@ async def async_setup_entry(
                     entry.data[CONF_NAME],
                     sensor_id,
                     # Friendly Name
-                    f"{output_name} State",
+                    f"Output {output_index}",
                 )
 
                 # Add our new output sensor

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -111,9 +111,10 @@ async def async_setup_entry(
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
 
+        output_index = 1
         for meta in outputs:
             output_name = meta["name"]
-            sensor_id = f"output_{output_name}"
+            sensor_id = f"output_{output_index}state"
             detected_sensors.add(sensor_id)
             if sensor_id not in sensors:
                 # hash our entry
@@ -123,7 +124,7 @@ async def async_setup_entry(
                     entry.data[CONF_NAME],
                     sensor_id,
                     # Friendly Name
-                    f"Output {output_name}",
+                    f"{output_name} State",
                 )
 
                 # Add our new output sensor
@@ -135,6 +136,8 @@ async def async_setup_entry(
             # Update our meta information
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
+            
+            output_index += 1
 
         if new_sensors:
             # Add our newly detected sensors

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -115,7 +115,7 @@ async def async_setup_entry(
             output_name = meta["name"]
             sensor_id = f"output_{output_name}"
             detected_sensors.add(sensor_id)
-            if sensor_id not in sensnors:
+            if sensor_id not in sensors:
                 # hash our entry
                 sensors[sensor_id] = UltraSyncSensor(
                     coordinator,

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -111,9 +111,10 @@ async def async_setup_entry(
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
 
+        output_index = 1
         for meta in outputs:
-            output_no = meta["name"]
-            sensor_id = "output{}state".format(output_no + 1)
+            output_name = meta["name"]
+            sensor_id = "output{}state".format(output_index)
             detected_sensors.add(sensor_id)
             if sensor_id not in sensors:
                 # hash our entry
@@ -123,18 +124,20 @@ async def async_setup_entry(
                     entry.data[CONF_NAME],
                     sensor_id,
                     # Friendly Name
-                    "Output{}State".format(output_no + 1),
+                    "Output{}State".format(output_index),
                 )
 
                 # Add our new output sensor
                 new_sensors.append(sensors[sensor_id])
                 _LOGGER.debug(
-                    "Detected %s.Output%dState", entry.data[CONF_NAME], output_no + 1
+                    "Detected %s.Output%dState", entry.data[CONF_NAME], output_index
                 )
             
             # Update our meta information
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
+
+            output_index += 1
 
         if new_sensors:
             # Add our newly detected sensors

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -111,10 +111,9 @@ async def async_setup_entry(
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
 
-        output_index = 1
         for meta in outputs:
-            output_name = meta["name"]
-            sensor_id = f"output_{output_name}"
+            output_no = meta["name"]
+            sensor_id = "output{}state".format(output_no + 1)
             detected_sensors.add(sensor_id)
             if sensor_id not in sensors:
                 # hash our entry
@@ -124,20 +123,18 @@ async def async_setup_entry(
                     entry.data[CONF_NAME],
                     sensor_id,
                     # Friendly Name
-                    f"Output {output_index}",
+                    "Output{}State".format(output_no + 1),
                 )
 
                 # Add our new output sensor
                 new_sensors.append(sensors[sensor_id])
                 _LOGGER.debug(
-                    "Detected %s.Output %s", entry.data[CONF_NAME], output_name
+                    "Detected %s.Output%dState", entry.data[CONF_NAME], output_no + 1
                 )
             
             # Update our meta information
             for key, value in meta.items():
                 sensors[sensor_id][key] = value
-            
-            output_index += 1
 
         if new_sensors:
             # Add our newly detected sensors

--- a/custom_components/ultrasync/services.yaml
+++ b/custom_components/ultrasync/services.yaml
@@ -36,3 +36,27 @@ unbypass:
           mode: box
           min: 1
           max: 100
+
+switch:
+  description: Switch an output control on or off.
+  fields:
+    output:
+      name: Output
+      description: The output control to switch.
+      required: true
+      example: 1
+      selector:
+        number:
+          mode: box
+          min: 1
+          max: 100
+    state:
+      name: State
+      description: The desired state for the output (0 for off, 1 for on).
+      required: true
+      example: 1
+      selector:
+        number:
+          mode: box
+          min: 0
+          max: 1


### PR DESCRIPTION
I've completed the output control changes so that it is now supported in the `ha-ultrasync` integration.

Changes made:
- Created a ultrasync `switch` service that executes the `set_output_control` function
- Created output sensors for each output

Before you merge it, I just need double checking that integration works for users who do not have an output control in there alarm. 

Also, the states of the output correctly initialise to 0 as they should when the integration is loaded but when the output is switched on, the sensor doesn't change state from 0 to 1. I think my code for the `coordinator.py` is not 100% correct. If you could take a look that would be great.

I haven't found any use case where the state of the output would need to be tracked as the main functionality of opening and closing the output through the switch is what i wanted to get working in home assistant. But having the output sensor state update as it should would be nice.