### PR TITLE
Fix 2024.3 issue

### DIFF
--- a/custom_components/ultrasync/__init__.py
+++ b/custom_components/ultrasync/__init__.py
@@ -65,8 +65,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     }
 
     for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+        entry.async_create_task(
+            hass, hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
     _async_register_services(hass, coordinator)
@@ -118,7 +118,7 @@ def _async_register_services(
     def unbypass(call) -> None:
         """Service call to unbypass a zone in UltraSync Hub."""
         coordinator.hub.set_zone_bypass(state=False, zone=call.data['zone'])
-    
+
     def switch(call) -> None:
         """Service call to switch on/off an output control in UltraSync Hub."""
         coordinator.hub.set_output_control(output=call.data['output'], state=call.data['state'])

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -145,7 +145,7 @@ async def async_setup_entry(
 
         for sensor_id in set(sensors.keys()).difference(detected_sensors):
             # Tidy up sensors leaving our listing
-            hass.async_create_task(sensors[sensor_id].async_remove())
+            entry.async_create_task(hass, sensors[sensor_id].async_remove())
             del sensors[sensor_id]
 
     # register our callback which will be called the second we make a


### PR DESCRIPTION
This PR contains two small changes:

1. In `_async_update_data` we move most of the code in the coroutine itself, and only the long-running `hub.details` is run in the executor thread. Calling async code from within the executor thread is not always possible, since there is no event loop there. I guess this was ok before 2024.3 but some internal change broke it (2024.3 contains various async changes to decrease boot time, eg the use of eager tasks supported in python 3.12).

2. `hass.async_create_task` is replaced by `entry.async_create_task`. This is likely unrelated to the issue, but the documentation suggestios that this is the way to call it.

I haven't tested the PR that much, but in my system it fixes the problems appeared in 2024.3.


