### PR TITLE
Replace deprecated HomeAssistantType with HomeAssistant

### DIFF
--- a/custom_components/ultrasync/__init__.py
+++ b/custom_components/ultrasync/__init__.py
@@ -4,8 +4,8 @@ import asyncio
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from ultrasync import AlarmScene
 import voluptuous as vol
@@ -28,14 +28,14 @@ from .coordinator import UltraSyncDataUpdateCoordinator
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistantType, config: dict) -> bool:
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the UltraSync integration."""
     hass.data.setdefault(DOMAIN, {})
 
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up UltraSync from a config entry."""
     if not entry.options:
         options = {
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(
@@ -94,7 +94,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> boo
 
 
 def _async_register_services(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     coordinator: UltraSyncDataUpdateCoordinator,
 ) -> None:
     """Register integration-level services."""
@@ -133,7 +133,7 @@ def _async_register_services(
         vol.Required('state'): vol.Coerce(int),
     }))
 
-async def _async_update_listener(hass: HomeAssistantType, entry: ConfigEntry) -> None:
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 

--- a/custom_components/ultrasync/config_flow.py
+++ b/custom_components/ultrasync/config_flow.py
@@ -10,8 +10,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 import ultrasync
 import voluptuous as vol
 
@@ -25,7 +25,7 @@ class AuthFailureException(IOError):
     """A general exception we can use to track Authentication failures."""
 
 
-def validate_input(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
+def validate_input(hass: HomeAssistant, data: dict) -> Dict[str, Any]:
     """Validate the user input allows us to connect."""
 
     usync = ultrasync.UltraSync(

--- a/custom_components/ultrasync/coordinator.py
+++ b/custom_components/ultrasync/coordinator.py
@@ -4,8 +4,8 @@ import logging
 
 from async_timeout import timeout
 from homeassistant.const import CONF_HOST, CONF_PIN, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import ultrasync
 
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class UltraSyncDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching UltraSync data."""
 
-    def __init__(self, hass: HomeAssistantType, *, config: dict, options: dict):
+    def __init__(self, hass: HomeAssistant, *, config: dict, options: dict):
         """Initialize global UltraSync data updater."""
         self.hub = ultrasync.UltraSync(
             user=config[CONF_USERNAME],

--- a/custom_components/ultrasync/sensor.py
+++ b/custom_components/ultrasync/sensor.py
@@ -5,10 +5,9 @@ from typing import Callable, List
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import callback
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import UltraSyncEntity
 from .const import (
@@ -24,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:


### PR DESCRIPTION
From my HA logs:
`HomeAssistantType was used from ultrasync, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.HomeAssistant instead, please report it to the author of the 'ultrasync' custom integration`

Renamed to HomeAssistant, as per log message, and here:
https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/